### PR TITLE
Multi-GPU training and fewer checkpoints

### DIFF
--- a/python/data.py
+++ b/python/data.py
@@ -26,3 +26,6 @@ training_columns_matching = [
     "pr_seed_chi2",
     "qop",
 ]
+
+boundaries = {"best_pt": (0, 1e4),
+              "chi2": (0, 400)}

--- a/python/inference.py
+++ b/python/inference.py
@@ -69,8 +69,7 @@ def command_line():
     parser.add_argument(
         "--config",
         help="Name of the file containing the model configuration.",
-        type=str,
-        required=True,
+        type=str
     )
     parser.add_argument(
         "--normalize",
@@ -140,14 +139,16 @@ def __main__():
     )
     # read model
     num_features = data.shape[1]
-    with open(arguments.config, "rb") as file:
-        model_config = pickle.load(file)
     if arguments.int8:
         model = torch.load(arguments.model)
     else:
         if "onnx" in arguments.model:
             model = onnx2torch.convert(arguments.model)
+            batch_size = 2048
         else:
+            with open(arguments.config, "rb") as file:
+                model_config = pickle.load(file)
+                batch_size = model_config["batch"]
             if arguments.network == 0:
                 model = GhostNetwork(
                     num_features,
@@ -176,7 +177,7 @@ def __main__():
     print(model)
     print()
     test_dataloader = DataLoader(
-        test_dataset, batch_size=model_config["batch"], shuffle=True
+        test_dataset, batch_size=batch_size, shuffle=True
     )
     loss_function = nn.BCELoss()
     # Accuracy test (CLI)

--- a/python/inference.py
+++ b/python/inference.py
@@ -6,6 +6,7 @@ import torch
 from torch import nn
 from torch.utils.data import DataLoader
 import onnx2torch
+import matplotlib
 import matplotlib.pyplot as plt
 
 from utilities import (
@@ -202,6 +203,8 @@ def __main__():
     plt.xticks(thresholds)
     plt.ylim(0, 1)
     plt.legend()
+    if not matplotlib.is_interactive():
+        plt.savefig("accuracy.png")
     plt.show()
     # Plot accuracy components
     tp = list()
@@ -257,6 +260,8 @@ def __main__():
     plt.plot(thresholds, nn_real, label="NN - Real Tracks")
     plt.xticks(thresholds)
     plt.legend()
+    if not matplotlib.is_interactive():
+        plt.savefig("ghost_real.png")
     plt.show()
     plt.plot(thresholds, g_tp, label="True Positives")
     plt.plot(thresholds, g_tn, label="True Negatives")
@@ -264,6 +269,8 @@ def __main__():
     plt.plot(thresholds, g_fn, label="False Negatives")
     plt.xticks(thresholds)
     plt.legend()
+    if not matplotlib.is_interactive():
+        plt.savefig("confusion.png")
     plt.show()
     plt.plot(thresholds, sensitivity, label="Sensitivity")
     plt.plot(thresholds, specificity, label="Specificity")
@@ -271,6 +278,8 @@ def __main__():
     plt.plot(thresholds, fpr, label="False Positive Rate")
     plt.xticks(thresholds)
     plt.legend()
+    if not matplotlib.is_interactive():
+        plt.savefig("ssfnfp.png")
     plt.show()
     plt.plot(fpr, sensitivity, label="Neural Network")
     plt.plot([0, 0.5, 1], [0, 0.5, 1], label="Random Classifier")
@@ -279,6 +288,8 @@ def __main__():
     plt.xlim(0, 1)
     plt.ylim(0, 1)
     plt.legend()
+    if not matplotlib.is_interactive():
+        plt.savefig("roc.png")
     plt.show()
     J = np.asarray(sensitivity) - np.asarray(fpr)
     f1_score = (np.asarray(tp) * 2) / (

--- a/python/make_dataset.py
+++ b/python/make_dataset.py
@@ -1,6 +1,7 @@
 import argparse
 import numpy as np
 import matplotlib.pyplot as plt
+import json
 
 from utilities import load_data, shuffle_data, remove_nans, normalize
 from data import label, training_columns_forward, training_columns_matching, boundaries
@@ -73,8 +74,8 @@ def __main__():
             plt.stairs(counts, bins, fill=True)
             plt.show()
     # Normalize each feature
+    features = {'features': [training_columns[feature_id] for feature_id in range(len(data))]}
     if arguments.normalize:
-        import json
         offsets_and_scales = {}
         for feature_id in range(len(data)):
             data_min_max = (float(np.min(data[feature_id])), float(np.max(data[feature_id])))
@@ -88,8 +89,9 @@ def __main__():
                 f"Feature: {feature_id} ({np.min(data[feature_id])}, {np.max(data[feature_id])})"
             )
             print()
-        with open(f"{arguments.output}_offsets_and_scales.json", "w") as jf:
-            json.dump(offsets_and_scales, jf)
+        features['offsets_and_scales'] = offsets_and_scales
+    with open(f"{arguments.output}_features.json", "w") as jf:
+        json.dump(features, jf, indent=4)
 
     # split into real and ghost tracks
     data = np.hstack([data[i].reshape(len(data[0]), 1) for i in range(len(data))])

--- a/python/make_dataset.py
+++ b/python/make_dataset.py
@@ -74,15 +74,23 @@ def __main__():
             plt.show()
     # Normalize each feature
     if arguments.normalize:
+        import json
+        offsets_and_scales = {}
         for feature_id in range(len(data)):
+            data_min_max = (float(np.min(data[feature_id])), float(np.max(data[feature_id])))
+            min_max = boundaries.get(training_columns[feature_id], data_min_max)
+            offsets_and_scales[training_columns[feature_id]] = (min_max[0], min_max[1] - min_max[0])
             print(
-                f"Feature: {feature_id} ({np.min(data[feature_id])}, {np.max(data[feature_id])})"
+                f"Feature: {feature_id} {data_min_max}"
             )
-            data[feature_id] = normalize(data[feature_id], min_max=boundaries.get(training_columns[feature_id], None))
+            data[feature_id] = normalize(data[feature_id], min_max)
             print(
                 f"Feature: {feature_id} ({np.min(data[feature_id])}, {np.max(data[feature_id])})"
             )
             print()
+        with open(f"{arguments.output}_offsets_and_scales.json", "w") as jf:
+            json.dump(offsets_and_scales, jf)
+
     # split into real and ghost tracks
     data = np.hstack([data[i].reshape(len(data[0]), 1) for i in range(len(data))])
     data_ghost = data[labels == 1]

--- a/python/make_dataset.py
+++ b/python/make_dataset.py
@@ -3,7 +3,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from utilities import load_data, shuffle_data, remove_nans, normalize
-from data import label, training_columns_forward, training_columns_matching
+from data import label, training_columns_forward, training_columns_matching, boundaries
 
 
 def command_line():
@@ -78,7 +78,7 @@ def __main__():
             print(
                 f"Feature: {feature_id} ({np.min(data[feature_id])}, {np.max(data[feature_id])})"
             )
-            data[feature_id] = normalize(data[feature_id])
+            data[feature_id] = normalize(data[feature_id], min_max=boundaries.get(training_columns[feature_id], None))
             print(
                 f"Feature: {feature_id} ({np.min(data[feature_id])}, {np.max(data[feature_id])})"
             )

--- a/python/training.py
+++ b/python/training.py
@@ -148,7 +148,7 @@ def __main__():
     tuner = tune.Tuner(
         tune.with_resources(
             tune.with_parameters(training_loop),
-            resources={"cpu": arguments.cpu, "gpu": arguments.gpu},
+            resources={"cpu": 1, "gpu": 0.25 if arguments.gpu > 0 else 0},
         ),
         tune_config=tune.TuneConfig(
             scheduler=scheduler, num_samples=arguments.num_samples

--- a/python/training.py
+++ b/python/training.py
@@ -132,8 +132,10 @@ def __main__():
                 nn.Softmin,
             ]
         ),
-        "training_dataset": (data_train, labels_train),
-        "validation_dataset": (data_validation, labels_validation),
+        'data_train': data_train,
+        'labels_train': labels_train,
+        'data_validation': data_validation,
+        'labels_validation': labels_validation,
         "network": arguments.network,
         "use_cuda": use_cuda,
         "loss_function": loss_function,
@@ -169,7 +171,7 @@ def __main__():
     model_state, _ = torch.load(checkpoint_path)
 
     # device for best model
-    if config['use_cuda']:
+    if use_cuda:
         device = torch.device(f"cuda:0")
     else:
         device = torch.device("cpu")

--- a/python/training.py
+++ b/python/training.py
@@ -139,6 +139,7 @@ def __main__():
         "network": arguments.network,
         "use_cuda": use_cuda,
         "loss_function": loss_function,
+        "tmp_path": arguments.tmp_path
     }
     if arguments.network == 1:
         tuning_config["normalization"] = tune.choice(

--- a/python/training.py
+++ b/python/training.py
@@ -156,6 +156,9 @@ def __main__():
         run_config=train.RunConfig(
             storage_path=arguments.path,
             log_to_file=True,
+            checkpoint_config=train.CheckpointConfig(
+                num_to_keep=5
+            )
         ),
         param_space=tuning_config,
     )

--- a/python/training.py
+++ b/python/training.py
@@ -79,11 +79,7 @@ def command_line():
 
 def __main__():
     arguments = command_line()
-    if not arguments.nocuda and torch.cuda.is_available():
-        device = torch.device(f"cuda:{arguments.cuda}")
-    else:
-        device = torch.device("cpu")
-    print(f"Device: {device}")
+    use_cuda = not arguments.nocuda and torch.cuda.is_available()
     # initialize ray
     ray.init(
         num_cpus=arguments.cpu,
@@ -104,18 +100,6 @@ def __main__():
     data_test = np.load(f"{arguments.filename}_test_data.npy")
     labels_test = np.load(f"{arguments.filename}_test_labels.npy")
     print(f"Test set size: {len(data_test)}")
-    training_dataset = GhostDataset(
-        torch.tensor(data_train, dtype=torch.float32, device=device),
-        torch.tensor(labels_train, dtype=torch.float32, device=device),
-    )
-    validation_dataset = GhostDataset(
-        torch.tensor(data_validation, dtype=torch.float32, device=device),
-        torch.tensor(labels_validation, dtype=torch.float32, device=device),
-    )
-    test_dataset = GhostDataset(
-        torch.tensor(data_test, dtype=torch.float32, device=device),
-        torch.tensor(labels_test, dtype=torch.float32, device=device),
-    )
     num_features = data_train.shape[1]
     num_epochs = arguments.epochs
     scheduler = ASHAScheduler(
@@ -148,10 +132,10 @@ def __main__():
                 nn.Softmin,
             ]
         ),
-        "training_dataset": training_dataset,
-        "validation_dataset": validation_dataset,
+        "training_dataset": (data_train, labels_train),
+        "validation_dataset": (data_validation, labels_validation),
         "network": arguments.network,
-        "device": device,
+        "use_cuda": use_cuda,
         "loss_function": loss_function,
     }
     if arguments.network == 1:
@@ -177,11 +161,19 @@ def __main__():
     print(f"Best trial config: {best_trial.config}")
     print(f"Best trial final validation loss: {best_trial.metrics['loss']}")
     print(f"Best trial final validation accuracy: {best_trial.metrics['accuracy']}")
+
     # load best model
     checkpoint_path = os.path.join(
         best_trial.checkpoint.to_directory(), "ghost_checkpoint.pt"
     )
     model_state, _ = torch.load(checkpoint_path)
+
+    # device for best model
+    if config['use_cuda']:
+        device = torch.device(f"cuda:0")
+    else:
+        device = torch.device("cpu")
+
     if arguments.network == 0:
         model = GhostNetwork(
             num_features,
@@ -212,6 +204,10 @@ def __main__():
     )
     print()
     # test accuracy
+    test_dataset = GhostDataset(
+        torch.tensor(data_test, dtype=torch.float32, device=device),
+        torch.tensor(labels_test, dtype=torch.float32, device=device),
+    )
     test_dataloader = DataLoader(test_dataset, batch_size=arguments.batch)
     accuracy, loss = testing_loop(
         device, model, test_dataloader, loss_function, arguments.threshold

--- a/python/training.py
+++ b/python/training.py
@@ -55,6 +55,12 @@ def command_line():
         default="/tmp/ghostprob/",
     )
     parser.add_argument(
+        "--tmp-path",
+        help="Where to store the tuning output.",
+        type=str,
+        default="/tmp/ray/",
+    )
+    parser.add_argument(
         "--cpu", help="Number of CPU cores to use for training.", type=int, default=1
     )
     parser.add_argument("--nocuda", help="Disable CUDA", action="store_true")
@@ -86,6 +92,7 @@ def __main__():
         log_to_driver=False,
         logging_level=logging.ERROR,
         include_dashboard=False,
+        _temp_dir=arguments.tmp_path
     )
     # create training, validation, and testing data sets
     data_train = np.load(f"{arguments.filename}_train_data.npy")
@@ -160,7 +167,6 @@ def __main__():
             scheduler=scheduler, num_samples=arguments.num_samples
         ),
         run_config=train.RunConfig(
-            local_dir=arguments.path,
             storage_path=arguments.path,
             log_to_file=True,
         ),

--- a/python/training.py
+++ b/python/training.py
@@ -106,7 +106,7 @@ def __main__():
         metric="loss",
         mode="min",
         max_t=num_epochs,
-        grace_period=2,
+        grace_period=8,
         reduction_factor=2,
     )
     loss_function = nn.BCELoss()

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -210,9 +210,12 @@ def remove_nans(data, labels):
     return data, labels
 
 
-def normalize(data: np.array) -> np.array:
-    minimum = np.min(data)
-    maximum = np.max(data)
+def normalize(data, min_max=None) -> np.array:
+    if min_max is None:
+        minimum = np.min(data)
+        maximum = np.max(data)
+    else:
+        minimum, maximum = min_max
     with np.errstate(divide="ignore"):
         if np.isfinite(np.random.rand(1) / (maximum - minimum)):
             return (data - minimum) / (maximum - minimum)

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -50,6 +50,22 @@ def select_optimizer(config, model):
 
 
 def training_loop(config):
+    if config['use_cuda']:
+        device = torch.device(f"cuda:0")
+    else:
+        device = torch.device("cpu")
+
+    data_train, labels_train = config['training_dataset']
+    training_dataset = GhostDataset(
+        torch.tensor(data_train, dtype=torch.float32, device=device),
+        torch.tensor(labels_train, dtype=torch.float32, device=device),
+    )
+    data_validation, labels_validation = config['validation_dataset']
+    validation_dataset = GhostDataset(
+        torch.tensor(data_validation, dtype=torch.float32, device=device),
+        torch.tensor(labels_validation, dtype=torch.float32, device=device),
+    )
+
     training_dataloader = DataLoader(
         config["training_dataset"], batch_size=int(config["batch"])
     )
@@ -79,7 +95,7 @@ def training_loop(config):
             device=config["device"],
         )
     optimizer = select_optimizer(config, model)
-    model = model.to(config["device"])
+    model = model.to(device)
     if train.get_checkpoint():
         loaded_checkpoint = train.get_checkpoint()
         with loaded_checkpoint.as_directory() as loaded_checkpoint_dir:

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -55,22 +55,24 @@ def training_loop(config):
     else:
         device = torch.device("cpu")
 
-    data_train, labels_train = config['training_dataset']
+    data_train = config['data_train']
+    labels_train = config['labels_train']
     training_dataset = GhostDataset(
         torch.tensor(data_train, dtype=torch.float32, device=device),
         torch.tensor(labels_train, dtype=torch.float32, device=device),
     )
-    data_validation, labels_validation = config['validation_dataset']
+    data_validation = config['data_validation']
+    labels_validation = config['labels_validation']
     validation_dataset = GhostDataset(
         torch.tensor(data_validation, dtype=torch.float32, device=device),
         torch.tensor(labels_validation, dtype=torch.float32, device=device),
     )
 
     training_dataloader = DataLoader(
-        config["training_dataset"], batch_size=int(config["batch"])
+        training_dataset, batch_size=int(config["batch"])
     )
     validation_dataloader = DataLoader(
-        config["validation_dataset"], batch_size=int(config["batch"])
+        validation_dataset, batch_size=int(config["batch"])
     )
     # model
     if config["network"] == 0:
@@ -92,7 +94,7 @@ def training_loop(config):
             l0=config["l0"],
             matching=True,
             activation=config["activation"],
-            device=config["device"],
+            device=device,
         )
     optimizer = select_optimizer(config, model)
     model = model.to(device)
@@ -110,12 +112,12 @@ def training_loop(config):
         inner_training_loop(
             model,
             training_dataloader,
-            config["device"],
+            device,
             optimizer,
             config["loss_function"],
         )
         accuracy, loss = testing_loop(
-            config["device"],
+            device,
             model,
             validation_dataloader,
             config["loss_function"],


### PR DESCRIPTION
- Move the treatment of the device fully into the `training_loop` function to allow different devices for different trials 
- Set the GPU requirements for a single trial to `0.25`, because the resource requirements are very small
- Reduce the number of checkpoints as writing them was costing the majority of the training time and took a lot of space

In addition for inference:
- Don't require PyTorch model state when running inference on an onnx model
- Save some png plots when the matplotlib session is not interactive

In addition for training:
- Allow setting of ray tmp path to avoid overloading /tmp